### PR TITLE
fix(encrypt): 修复密文过长时的 Base64 转换错误

### DIFF
--- a/src/utils/encrypt.ts
+++ b/src/utils/encrypt.ts
@@ -1,9 +1,9 @@
 /**
  * 异步加密函数
- * 
+ *
  * @param data 要加密的字符串
  * @param key 密码
- * 
+ *
  * @returns 加密后的 Base64 字符串
  */
 export async function encrypt(data: string, key: string): Promise<string> {
@@ -33,5 +33,14 @@ export async function encrypt(data: string, key: string): Promise<string> {
   combinedData.set(iv);
   combinedData.set(new Uint8Array(encryptedData), iv.length);
   // 转成 Base64 字符串返回
-  return btoa(String.fromCharCode(...combinedData));
+  return uint8ToBase64(combinedData);
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
 }


### PR DESCRIPTION
由于 String.fromCharCode(...Uint8Array) 会在数组较大时触发参数数量限制，
导致加密内容较长时出现报错。改为循环构建 binary 字符串后再调用 btoa。